### PR TITLE
feat: allow user to pass events to bind to

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Usage
 <div {{click-outside this.onClickOutside}}></div>
 ```
 
+You can also provide specific events that you want to bind to with the `event` or `events` named arguments.
+
+```hbs
+<div {{click-outside this.onClickOutside event='mouseup'}}></div>
+<div {{click-outside this.onClickOutside events=(array 'click' 'mouseup')}}></div>
+```
+
 
 Contributing
 ------------------------------------------------------------------------------

--- a/addon/modifiers/click-outside.js
+++ b/addon/modifiers/click-outside.js
@@ -8,7 +8,20 @@ const EVENTS = IS_TOUCH ? ['touchstart'] : ['click']
 
 import { modifier } from 'ember-modifier';
 
-export default modifier(function clickOutside(element, [handlerValue, useCapture] = [undefined, false]) {
+function getEventNames({ event, events }) {
+  if (events) {
+    return events;
+  }
+
+  if (event) {
+    return [event];
+  }
+
+  return EVENTS;
+}
+
+export default modifier(function clickOutside(element, [handlerValue, useCapture] = [undefined, false], hashParams = {}) {
+    const events = getEventNames(hashParams);
     const isFunction = typeof handlerValue === 'function'
     if (!isFunction) {
       throw new Error(
@@ -16,7 +29,7 @@ export default modifier(function clickOutside(element, [handlerValue, useCapture
       )
     }
     const handlers = [];
-    EVENTS.forEach((eventName)=>{
+    events.forEach((eventName)=>{
         const handler = (event) => {
             const isClickOutside = event.target !== element && !element.contains(event.target);
             if (!isClickOutside) {

--- a/tests/integration/modifiers/click-outside-test.js
+++ b/tests/integration/modifiers/click-outside-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render, click, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Modifier | click-outside', function(hooks) {
@@ -42,6 +42,34 @@ module('Integration | Modifier | click-outside', function(hooks) {
     assert.equal(outsideClicked, false);
     await click('.outside');
     assert.equal(outsideClicked, true);
+  });
+  module('configurable event bindings', function() {
+    test('single event', async function(assert) {
+      let outsideClicked = false;
+      this.set('onClickOutside',()=>{
+        outsideClicked = true;
+      });
+      await render(hbs`<div class="outside"><div {{click-outside this.onClickOutside event="mouseup"}}><div class="inside"></div></div></div>`);
+      assert.ok(true);
+      await triggerEvent('.inside', 'mouseup');
+      assert.equal(outsideClicked, false);
+      await triggerEvent('.outside', 'mouseup');
+      assert.equal(outsideClicked, true);
+    });
+    test('multiple events', async function(assert) {
+      let outsideClicked = 0;
+      this.set('onClickOutside',()=>{
+        outsideClicked++;
+      });
+      await render(hbs`<div class="outside"><div {{click-outside this.onClickOutside events=(array "mouseup" "click")}}><div class="inside"></div></div></div>`);
+      assert.ok(true);
+      await triggerEvent('.inside', 'mouseup');
+      await triggerEvent('.inside', 'click');
+      assert.equal(outsideClicked, 0);
+      await triggerEvent('.outside', 'mouseup');
+      await triggerEvent('.outside', 'click');
+      assert.equal(outsideClicked, 2);
+    });
   });
   // test('error case', async function(assert) {
   //   try {


### PR DESCRIPTION
This adds the ability to provide custom events to bind to if the default names aren't right for the use-case that user has.

`events` and `event` are both supported, so that the user doesn't have to manually wrap a single event name with the `(array)` helper or deal with the awkwardness of passing a single string to a param named `events`.

This came out of trying to land this PR to `ember-headlessui`

https://github.com/GavinJoyce/ember-headlessui/pull/43

That addon used to ship it's own `click-outside` modifier that binds to `mouseup`. I wanted to replace it with this addon so that we don't have the duplication/conflict in our app, but the un-override-able `click` binding caused some problems. Rather than trying something hack-y in that addon, it felt right to allow this configuration option upstream and then leverage a custom event binding in that addon to preserve the original behavior.