### PR TITLE
Drop Node.js 12 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --no-lockfile
@@ -76,7 +76,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 14.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Compatibility
 
 * Ember.js v3.16 or above
 * Ember CLI v2.13 or above
-* Node.js v12 or above
+* Node.js v14 or above
 
 
 Installation

--- a/addon/package.json
+++ b/addon/package.json
@@ -30,7 +30,7 @@
     "prettier": "^2.5.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || 16.* || >= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -68,7 +68,7 @@
     "webpack": "^5.70.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Per https://nodejs.org/en/about/releases/ reaches End Of Life on 2022-04-30 which is this month.

@lifeart as we plan major release as part of #12, it worth considering if we should include this part as well.