### PR TITLE
Prepare for ember-modifier v4

### DIFF
--- a/addon/src/modifiers/click-outside.js
+++ b/addon/src/modifiers/click-outside.js
@@ -20,40 +20,43 @@ function getEventNames({ event, events }) {
   return EVENTS;
 }
 
-export default modifier(function clickOutside(
-  element,
-  [handlerValue, useCapture] = [undefined, false],
-  hashParams = {}
-) {
-  const refEvent = new Event('clickReference');
-  const events = getEventNames(hashParams);
-  const isFunction = typeof handlerValue === 'function';
-  if (!isFunction) {
-    throw new Error('{{click-outside}}: Handler value must be a function.');
-  }
-  const handlers = [];
-  events.forEach((eventName) => {
-    const handler = (event) => {
-      if (refEvent.timeStamp > event.timeStamp) {
-        return;
-      }
-      const isClickOutside =
-        event.target !== element && !element.contains(event.target);
-      if (!isClickOutside) {
-        return;
-      }
-      handlerValue(event);
-    };
-    handlers.push([eventName, handler]);
-    document.documentElement.addEventListener(eventName, handler, useCapture);
-  });
-  return () => {
-    handlers.forEach(([eventName, handler]) => {
-      document.documentElement.removeEventListener(
-        eventName,
-        handler,
-        useCapture
-      );
+export default modifier(
+  function clickOutside(
+    element,
+    [handlerValue, useCapture] = [undefined, false],
+    hashParams = {}
+  ) {
+    const refEvent = new Event('clickReference');
+    const events = getEventNames(hashParams);
+    const isFunction = typeof handlerValue === 'function';
+    if (!isFunction) {
+      throw new Error('{{click-outside}}: Handler value must be a function.');
+    }
+    const handlers = [];
+    events.forEach((eventName) => {
+      const handler = (event) => {
+        if (refEvent.timeStamp > event.timeStamp) {
+          return;
+        }
+        const isClickOutside =
+          event.target !== element && !element.contains(event.target);
+        if (!isClickOutside) {
+          return;
+        }
+        handlerValue(event);
+      };
+      handlers.push([eventName, handler]);
+      document.documentElement.addEventListener(eventName, handler, useCapture);
     });
-  };
-});
+    return () => {
+      handlers.forEach(([eventName, handler]) => {
+        document.documentElement.removeEventListener(
+          eventName,
+          handler,
+          useCapture
+        );
+      });
+    };
+  },
+  { eager: false }
+);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "prepare": "cd addon && yarn build",
-    "test": "cd test-app && yarn test"
+    "test": "cd test-app && yarn test:ember"
   },
   "devDependencies": {
     "release-it": "^14.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4898,9 +4898,9 @@ ember-maybe-import-regenerator@^1.0.0:
     regenerator-runtime "^0.13.2"
 
 ember-modifier@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.1.tgz#7078403b5b84d7b97d0b3298851d33d098a7b82d"
-  integrity sha512-8mMLUX/pclAfrX99RemTsyimVM/8zJ1ZzGOqny2TfUKeFzon3a+mxPUmBhY+TS6W4aNBW32YSeFytEtG01bTdQ==
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.5.tgz#b82052afe941f3b27c0840019992d59466dfbd77"
+  integrity sha512-66YA4pQijoDIAfoI0pYAhjYWu/VrTaD3BfxpA311hLIoBlaI2QQY/LR+32aah1EvKY/yInnCJA5wcl7C+f3mkg==
   dependencies:
     ember-cli-babel "^7.26.6"
     ember-cli-normalize-entity-name "^1.0.0"


### PR DESCRIPTION
This PR follows [`ember-modifier` v4 migration guide](https://github.com/ember-modifier/ember-modifier/blob/v3.2.5/MIGRATIONS.md#function-based-modifiers)

Note that `ember-modifier` v4 has not yet been released however [v3.2.0](https://github.com/ember-modifier/ember-modifier/releases/tag/v3.2.0) was *already* released adding deprecations.

This PR removes those deprecations and makes addon future ready.