### PR TITLE
auto-publish unstable packages to NPM

### DIFF
--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -1,0 +1,41 @@
+# For every push to the master branch, this publishes an NPM package to the
+# "unstable" NPM tag.
+
+name: Publish Unstable
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  publish:
+    name: "NPM Publish"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+          cache: yarn
+          # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      # We need a workspace aware version of npm because our addon is in a subdir but our .npmrc is in the root
+      - name: npm8
+        run: npm install -g npm@8
+
+      - name: set version
+        run: npm version --no-git-tag-version --workspaces-update=false `node -e "console.log(require('./package.json').version)"`-unstable.`git rev-parse --short HEAD`
+        working-directory: addon
+
+      - name: npm publish
+        run: npm publish --tag=unstable --verbose --workspace=addon
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,9 +30,9 @@ Once the prep work is completed, the actual release is straight forward:
 
 * First, ensure that you have installed your projects dependencies:
 
-```sh
-yarn install
-```
+  ```sh
+  yarn install
+  ```
 
 * Second, ensure that you have obtained a
   [GitHub personal access token][generate-token] with the `repo` scope (no
@@ -45,16 +45,21 @@ yarn install
   export GITHUB_AUTH=abc123def456
   ```
 
-[generate-token]: https://github.com/settings/tokens/new?scopes=repo&description=GITHUB_AUTH+env+variable
+  [generate-token]: https://github.com/settings/tokens/new?scopes=repo&description=GITHUB_AUTH+env+variable
 
 * And last (but not least 😁) do your release.
 
-```sh
-yarn release-it
-```
+  ```sh
+  yarn release-it
+  ```
 
 [release-it](https://github.com/release-it/release-it/) manages the actual
 release process. It will prompt you to choose the version number after which
 you will have the chance to hand tweak the changelog to be used (for the
 `CHANGELOG.md` and GitHub release), then `release-it` continues on to tagging,
 pushing the tag and commits, etc.
+
+## Unstable Tag
+
+For every push to the master branch, [`Publish Unstable`](./.github/workflows/publish-unstable.yml)
+publishes an NPM package to the "unstable" NPM tag.


### PR DESCRIPTION
As there's no convenient way to point NPM directly at a monorepo, and even if you could the package does have a required build step.

The build step for v2 addons was a deliberate design choice, because in the normal case apps can have much faster builds if all their addons are already prebuilt before publishing. But it does make the case of using unreleased code more manual.

This PR adds workflow to automatically publish alpha releases to NPM for every commit to the master branch.

This is inspired by setup in https://github.com/ember-animation/ember-animated/blob/master/.github/workflows/publish-unstable.yml

@lifeart would you be open doing this? If yes - could you please add npm token as `NODE_AUTH_TOKEN` secret to the repository config?