### PR TITLE
Remove engines field from addon package.json

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
 
       - name: Install Dependencies
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
 
       - name: Install Dependencies
@@ -83,7 +83,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: yarn
 
       - name: Install Dependencies

--- a/.github/workflows/publish-unstable.yml
+++ b/.github/workflows/publish-unstable.yml
@@ -19,7 +19,7 @@ jobs:
       # - name: Install Node
       #   uses: actions/setup-node@v3
       #   with:
-      #     node-version: 14.x
+      #     node-version: 16.x
       #     cache: yarn
       #     # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
       #     registry-url: 'https://registry.npmjs.org'

--- a/ember-click-outside-modifier/package.json
+++ b/ember-click-outside-modifier/package.json
@@ -47,9 +47,6 @@
     "prettier": "^2.6.2",
     "rollup": "^2.70.2"
   },
-  "engines": {
-    "node": "14.* || 16.* || >= 18"
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },


### PR DESCRIPTION
Per https://github.com/embroider-build/addon-blueprint/blob/main/files/__addonLocation__/package.json `engines` field is not needed in the addon package.json as v2 addons don't have any Node.js runtime.

This would safe us from need for major version bump when we need to bump Node for CI compatibility purposes only.